### PR TITLE
Modification to the Command.cs overloaded functions RunProcessReturnOutput

### DIFF
--- a/AndroidLib/Classes/Util/Command.cs
+++ b/AndroidLib/Classes/Util/Command.cs
@@ -87,6 +87,9 @@ namespace RegawMOD
                     }
                 }
                 string strReturn = "";
+                /* It's more accurate to check for length of a string when we are expecting an empty string after calling Trim().
+ -               * Submitted By: Omar Bizreh [DeepUnknown from Xda-Developers.com]
+ -               */
                 if (error.ToString().Trim().Length.Equals(0))
                     strReturn = output.ToString().Trim();
                 else
@@ -155,6 +158,9 @@ namespace RegawMOD
                     }
                 }
                 string strReturn = "";
+                /* It's more accurate to check for length of a string when we are expecting an empty string after calling Trim().
+ -               * Submitted By: Omar Bizreh [DeepUnknown from Xda-Developers.com]
+ -               */
                 if (error.ToString().Trim().Length.Equals(0) || forceRegular)
                     strReturn = output.ToString().Trim();
                 else                


### PR DESCRIPTION
I am submitting this pull request as you requested in response to my post on XDA, with minor modifications to the code I posted on XDA to reflect the original intention of the methods, such as the forceRegular boolean and only returning the error string if it has length greater than zero.
