### PR TITLE
Bug fix

### DIFF
--- a/AndroidLib/Classes/AndroidController/AndroidController.cs
+++ b/AndroidLib/Classes/AndroidController/AndroidController.cs
@@ -127,11 +127,18 @@ namespace RegawMOD.Android
         #region PRIVATE METHODS
         private void CreateResourceDirectories()
         {
-            if (!Adb.ExecuteAdbCommand(new AdbCommand("version")).Contains(Adb.ADB_VERSION))
+            try
             {
-                Adb.KillServer();
-                Thread.Sleep(1000);
-                ResourceFolderManager.Unregister(ANDROID_CONTROLLER_TMP_FOLDER);
+                if (!Adb.ExecuteAdbCommand(new AdbCommand("version")).Contains(Adb.ADB_VERSION))
+                {
+                    Adb.KillServer();
+                    Thread.Sleep(1000);
+                    ResourceFolderManager.Unregister(ANDROID_CONTROLLER_TMP_FOLDER);
+                    Extract_Resources = true;
+                }
+            }
+            catch (Exception)
+            {
                 Extract_Resources = true;
             }
             ResourceFolderManager.Register(ANDROID_CONTROLLER_TMP_FOLDER);


### PR DESCRIPTION
After doing some more tests, I found out that block of code will raise
an exception if the library is running for the first time (which means
we have no resources extracted). To deal with it, we simply set
"Extract_Resources" to true and everything will continue they way it
should.
