### PR TITLE
Add ADB Sideload

### DIFF
--- a/AndroidLib/Classes/AndroidController/Device.cs
+++ b/AndroidLib/Classes/AndroidController/Device.cs
@@ -74,6 +74,8 @@ namespace RegawMOD.Android
                     return DeviceState.RECOVERY;
                 case "fastboot":
                     return DeviceState.FASTBOOT;
+                case "sideload":
+                    return DeviceState.SIDELOAD;
                 case "unauthorized":
                     return DeviceState.UNAUTHORIZED;
                 default:

--- a/AndroidLib/Classes/AndroidController/Enums.cs
+++ b/AndroidLib/Classes/AndroidController/Enums.cs
@@ -56,6 +56,11 @@ namespace RegawMOD.Android
         FASTBOOT,
 
         /// <summary>
+        /// <see cref="Device"/> is in sideload mode
+        /// </summary>
+        SIDELOAD,
+
+        /// <summary>
         /// <see cref="Device"/> is not authorized
         /// </summary>
         UNAUTHORIZED,


### PR DESCRIPTION
Some recoveries support ADB Sideload. This mode will accept a zip to be
flashed to the phone.